### PR TITLE
Fix: Add trailing empty cells to calendar grid for proper 7-column al…

### DIFF
--- a/src/Calendar.tsx
+++ b/src/Calendar.tsx
@@ -221,6 +221,9 @@ const Calendar = ({
 
     for (let i = 0; i < startOffset; i++) days.push(null);
     for (let d = 1; d <= last.getDate(); d++) days.push(new Date(y, m, d));
+        // Pad with trailing empty cells to complete the grid (ensure 7-column layout)
+    const remainingCells = (7 - (days.length % 7)) % 7;
+    for (let i = 0; i < remainingCells; i++) days.push(null);
 
     return days;
   };


### PR DESCRIPTION
…ignment  This fixes issue #4 where months that don't end on Saturday were displaying incomplete calendar rows. The getDays() function now pads the days array with trailing null values to ensure the calendar grid always maintains a complete 7-column layout for proper visual alignment.

Add padding with trailing empty cells to ensure a 7-column layout in the calendar.

# 🔀 Pull Request

## 📌 Issue Reference  
<!-- Link to the issue this PR addresses. PRs without an issue reference may not be merged. -->
Closes #<issue_number>  
<!-- Example: Closes #244 -->

---

## 📝 Summary  
<!-- Clearly describe the problem and the solution introduced in this PR. -->
- What issue does this fix?
- What major changes were made?

---

## 📸 Screenshots (if applicable)  
<!-- Include relevant screenshots or screen recordings to demonstrate your changes. -->

---

## ✅ Checklist  
- [ ] My code follows the project's coding conventions  
- [ ] I have tested all impacted features  
- [ ] I have updated or added necessary documentation  

---

## 🔗 Related Issues / PRs  
<!-- List any related issues or PRs for context. -->

---

## 🏅 Open Source Program Participation  
<!-- If contributing under an open-source program, mention it here. -->
Program Name: <!-- Example: GSoC, Hacktoberfest -->

---

## 💬 Additional Notes  
<!-- Add any other relevant information or context. -->